### PR TITLE
Fixed K-LMS naming to match v1

### DIFF
--- a/src/rp_schema.py
+++ b/src/rp_schema.py
@@ -48,7 +48,7 @@ INPUT_SCHEMA = {
         'type': str,
         'required': False,
         'default': 'DPMSolverMultistep',
-        'constraints': lambda scheduler: scheduler in ['DDIM', 'K_EULER', 'DPMSolverMultistep', 'K_EULER_ANCESTRAL', 'PNDM', 'KLMS']
+        'constraints': lambda scheduler: scheduler in ['DDIM', 'K_EULER', 'DPMSolverMultistep', 'K_EULER_ANCESTRAL', 'PNDM', 'K-LMS']
     },
     'seed': {
         'type': int,


### PR DESCRIPTION
On v2 worker K-LMS was named KLMS.
This PR fixes it to match V1 endpoint.